### PR TITLE
Resolving Trace File Unavailability Issue in #37

### DIFF
--- a/simulation/run.py
+++ b/simulation/run.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
 	parser.add_argument('--hpai', dest='hpai', action='store', type=int, default=0, help="AI for HPCC")
 	parser.add_argument('--pint_log_base', dest='pint_log_base', action = 'store', type=float, default=1.01, help="PINT's log_base")
 	parser.add_argument('--pint_prob', dest='pint_prob', action = 'store', type=float, default=1.0, help="PINT's sampling probability")
-	parser.add_argument('--enable_tr', dest='enable_tr', action = 'store', type=int, default=0, help="enable packet-level events dump")
+	parser.add_argument('--enable_tr', dest='enable_tr', action = 'store', type=int, default=1, help="enable packet-level events dump")
 	args = parser.parse_args()
 
 	topo=args.topo


### PR DESCRIPTION
The problem with issue #37 is that the default value for 'enable_tr' (_the value set for 'ENABLE_TRACE' in the config file generation process_) is currently set to 0. This means that when you use the 'run.py' command mentioned in '/simulation/Readme.md' to generate a config file, it creates a trace file with no useful information.

> Just to clarify, this issue has nothing to do with 'third.cc'.

Hope that this change can be merged because it will greatly help newcomers who are just starting to use HPCC code for congestion control simulations.