### PR TITLE
The ACK_HIGH_PRIO option in the config file should set the value of SwitchNode::m_ackHighPrio

### DIFF
--- a/simulation/scratch/third.cc
+++ b/simulation/scratch/third.cc
@@ -846,6 +846,7 @@ int main(int argc, char *argv[])
 			sw->m_mmu->ConfigNPort(sw->GetNDevices()-1);
 			sw->m_mmu->ConfigBufferSize(buffer_size* 1024 * 1024);
 			sw->m_mmu->node_id = sw->GetId();
+			sw->SetAttribute("AckHighPrio", UintegerValue(ack_high_prio));
 		}
 	}
 


### PR DESCRIPTION
### PR Description

The `ACK_HIGH_PRIO` option in the `config` file is intended to control whether ACK packets are placed in the high-priority queue of the NICs and switches in network. 

In `third.cc`, the following code uses the `ACK_HIGH_PRIO` setting to decide whether ACK packets should be placed in the highest priority queue on the NIC.

```cpp
// Set ACK priority on hosts
if (ack_high_prio)
    RdmaEgressQueue::ack_q_idx = 0;
else
    RdmaEgressQueue::ack_q_idx = 3;
```

However, in `third.cc`, there is no code that sets the value of `SwitchNode::m_ackHighPrio`. As a result, regardless of the `ACK_HIGH_PRIO` value in the config file, `SwitchNode::m_ackHighPrio` is always `0`. This causes ACK packets to always share the same queue with other packets on the switch, regardless of the configuration.

This PR addresses the issue by ensuring that `SwitchNode::m_ackHighPrio` is correctly set based on the `ACK_HIGH_PRIO` option in the config file.
